### PR TITLE
Fix for options screen translation

### DIFF
--- a/Data/Translations_en.tsv
+++ b/Data/Translations_en.tsv
@@ -1475,5 +1475,5 @@ id	text	en	loc
 12477	slow	slow	Options.dinky
 12478	normal	normal	Options.dinky
 12479	fast	fast	Options.dinky
-12460	faster	faster	Options.dinky
-12461	fastest	fastest	Options.dinky
+12480	faster	faster	Options.dinky
+12481	fastest	fastest	Options.dinky

--- a/Scripts/Helpers/Options.dinky
+++ b/Scripts/Helpers/Options.dinky
@@ -336,11 +336,11 @@ function openOptions(save_state=YES) {
 		if (v == 5) { t = TEXT(12477,"slow"); p = 1.25 }
 		if (v == 4) { t = TEXT(12478,"normal"); p = 1.0 }
 		if (v == 3) { t = TEXT(12479,"fast"); p = 0.75 }
-		if (v == 2) { t = TEXT(12460,"faster"); p = 0.5 }
-		if (v == 1) { t = TEXT(12461,"fastest"); p = 0.25 }
+		if (v == 2) { t = TEXT(12480,"faster"); p = 0.5 }
+		if (v == 1) { t = TEXT(12481,"fastest"); p = 0.25 }
 
 		gameprop("sayLineSpeed", p)
-		return format(TR(TEXT(12328,"Text speed: %s")), t)
+		return format(TR(TEXT(12328,"Text speed: %s")), TR(t))
 	})
 
 	local ok_button = null


### PR DESCRIPTION
## Changes:

Text option wrapper IDs corrected (wrong numbering) and added missing call to translation before string concatenatin

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial or non-commercial release of Terrible Toybox games.
- [x] If Terrible Toybox finds the change to be substantial, I will be credited in the Additional Credits section of the Options for all of said releases, but will NOT be compensated
  for these changes.
