### PR TITLE
Wrong bracket balancing in TR fixed

### DIFF
--- a/Scripts/Inventory.dinky
+++ b/Scripts/Inventory.dinky
@@ -672,7 +672,7 @@ DEFINE_ROOM("Inventory", {
 			if (Note.isActiveStory("cleaning_up") && !Note.isStoryPhotographed("cleaning_up")) {
 				if (this.dust_count < SETTING(specks_of_dust_complete)) {
 					sayLine(SAY(11969,"I don't think this is enough dust for Natalie."),
-					        format(TR(SAY(11970,"^She probably needs around %d specks of dust."), SETTING(specks_of_dust_complete))))
+					        format(TR(SAY(11970,"^She probably needs around %d specks of dust.")), SETTING(specks_of_dust_complete)))
 				} else {
 					sayLine(randomfrom(SAY(11971,"That's a good shot!"),
 					                   SAY(11972,"Natalie will love this one!"),


### PR DESCRIPTION
Translation crashed with specks of dusts due to wrong balancing of parentheses

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial or non-commercial release of Terrible Toybox games.
- [x] If Terrible Toybox finds the change to be substantial, I will be credited in the Additional Credits section of the Options for all of said releases, but will NOT be compensated
  for these changes.
