### PR TITLE
verbMenuSpacing set to 33

### DIFF
--- a/Scripts/Settings.dinky
+++ b/Scripts/Settings.dinky
@@ -40,7 +40,7 @@ DEBUG(pickup) <- getDebugSetting("debugPickup", NO)
 
 SETTING(verbmenu_offset) <- point(0, getSetting("verbMenuOffset", 25))
 SETTING(verbmenu_scale) <- max(min(getSetting("verbMenuScale", 3.0), 4.0), 1.0)
-SETTING(verbmenu_spacing) <- getSetting("verbMenuSpacing", 27)
+SETTING(verbmenu_spacing) <- getSetting("verbMenuSpacing", 33)
 
 SETTING(inventory_spacing) <- getSetting("inventorySpacing", point(10,70))
 


### PR DESCRIPTION
## Changes:

increased verbMenuSpacing (27 -> 33) to create space for diacritical marks

## Legal Stuff:

By submitting this pull request, I confirm that...

- [x] My changes may be used in a future commercial or non-commercial release of Terrible Toybox games.
- [x] If Terrible Toybox finds the change to be substantial, I will be credited in the Additional Credits section of the Options for all of said releases, but will NOT be compensated
  for these changes.
